### PR TITLE
Fix issue #5: Vagrant up fails, needs Ruby >= 2.0

### DIFF
--- a/VagrantFile
+++ b/VagrantFile
@@ -6,7 +6,7 @@ Vagrant::Config.run do |config|
   config.vm.box_url = "http://files.vagrantup.com/precise32.box"
   config.vm.forward_port 8124, 8124
   config.vm.provision :shell,
-    :inline => "sudo apt-get update && sudo apt-get -y install build-essential git ruby1.9.3 && sudo gem install github-pages therubyracer --no-ri --no-rdoc"
+   :inline => "sudo apt-get update && sudo apt-get -y install python-software-properties && sudo apt-add-repository ppa:brightbox/ruby-ng && sudo apt-get update && sudo apt-get -y install build-essential git ruby2.2 ruby2.2-dev && sudo gem install github-pages therubyracer --no-ri --no-rdoc"
 
   config.ssh.forward_agent = true
-end
+end 


### PR DESCRIPTION
The gem github-pages was recently changed from Ruby 1.9.3 to 2.2.1

I've modified the VagrantFile to use the brightbox repo which has a copy of Ruby 2.2